### PR TITLE
Přesunutí Tieto kurzu do runs/2018

### DIFF
--- a/courses/info.yml
+++ b/courses/info.yml
@@ -1,4 +1,4 @@
 order:
 - pyladies
 - mi-pyt
-- tieto
+

--- a/runs/2018/tieto/info.yml
+++ b/runs/2018/tieto/info.yml
@@ -17,6 +17,7 @@ vars:
 plan:
 - title: Instalace
   slug: install
+  date: 2018-10-10
   materials:
   - lesson: beginners/cmdline
   - lesson: beginners/install
@@ -27,52 +28,62 @@ plan:
 
 - title: Seznamy a N-tice (Lists and Tupples)
   slug: lists-and-tupples
+  date: 2018-10-10
   materials:
   - lesson: beginners/list
   - lesson: beginners/tuple
 
 - title: Práce s řetězci
   slug: strings
+  date: 2018-10-10
   materials:
   - lesson: beginners/str
 
 - title: Slovníky (Dictionaries)
   slug: dictionaries
+  date: 2018-10-10
   materials:
   - lesson: beginners/dict
 
 - title: Podmínky a smyčky
   slug: conditionals-loops
+  date: 2018-10-10
   materials:
   - lesson: beginners/while
 
 - title: Abstrakce - Funkce
   slug: functions
+  date: 2018-10-10
   materials:
   - lesson: beginners/def
 
 - title: Abstrakce - Třídy
   slug: classes
+  date: 2018-10-10
   materials:
   - lesson: beginners/class
 
 - title: Moduly, balíly a další
   slug: modules-and-stuff
+  date: 2018-10-10
   materials:
   - lesson: beginners/modules
 
 - title: Soubory a výjimky
   slug: files-and-exceptions
+  date: 2018-10-10
   materials:
   - lesson: beginners/files
   - lesson: beginners/exceptions
 
 - title: Testování
   slug: testing
+  date: 2018-10-10
   materials:
   - lesson: beginners/testing
 
 - title: Síťové programování
   slug: network-programming
+  date: 2018-10-10
   materials:
   - lesson: beginners/networking


### PR DESCRIPTION
V `courses` jsou hotové kurzy, které doporučujeme pro samostudium. Ten z Tieta zatím doporučit nemůžeme – některé kapitoly nejsou hotové.
Proto je ho potřeba přesunout do `runs/`, jako konkrétní běh kurzu.
Data jednotlivých lekcí si prosím potom doplňte.