### PR TITLE
Add naucse_render dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ cssutils
 gitpython
 click
 giturlparse
+naucse_render<1.0


### PR DESCRIPTION
We're making changes to naucse and need to add `naucse_render` to this fork.
(See https://github.com/pyvec/naucse.python.cz/issues/494 and https://github.com/pyvec/naucse.python.cz/pull/505 for all the details.)
