### PR TITLE
Update index.md

### DIFF
--- a/lessons/beginners/tieto-dictionaries/index.md
+++ b/lessons/beginners/tieto-dictionaries/index.md
@@ -193,7 +193,7 @@ Sometimes you want also delete all referenced objects values as well:
 >>> y
 {'key': 'value'}
 >>> x = {}
->>> x = {}
+>>> y
 {'key': 'value'}
 ```
 


### PR DESCRIPTION
Miesto 
>>> y
{'key': 'value'}
je tam
>>> x = {}
{'key': 'value'}
asi chcel autor ukázať, že aj keď k "x" priradil prázdny dictionary, tak y bude stále pôvodný dictionary, miesto toho tam nesprávne ukazuje, že x = {} returns pôvodný dictionary "{key': 'value'}"